### PR TITLE
Get rate limit configuration from appsettings.json

### DIFF
--- a/src/Diksy.Translation.History/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Diksy.Translation.History/Extensions/ServiceCollectionExtensions.cs
@@ -12,13 +12,13 @@ namespace Diksy.Translation.History.Extensions
         private const string DefaultDatabaseName = "diksy";
 
         public static IServiceCollection AddTranslationHistory(this IServiceCollection services,
-            IConfiguration configuration, string mongoDbSectionName = "MongoDb")
+            IConfiguration configuration, string sectionName)
         {
             services.AddScoped<ITranslationHistoryService, TranslationHistoryService>();
 
-            services.AddMongo(configuration, mongoDbSectionName);
+            services.AddMongo(configuration, sectionName);
 
-            IConfigurationSection mongoDbOptionsSection = configuration.GetSection(mongoDbSectionName);
+            IConfigurationSection mongoDbOptionsSection = configuration.GetSection(sectionName);
             MongoDbOptions mongoDbOptions = mongoDbOptionsSection.Get<MongoDbOptions>() ?? new MongoDbOptions();
 
             services.AddMongoRepository<TranslationHistoryEntry>(

--- a/src/Diksy.Translation.OpenAI/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Diksy.Translation.OpenAI/Extensions/ServiceCollectionExtensions.cs
@@ -9,13 +9,11 @@ namespace Diksy.Translation.OpenAI.Extensions
 {
     public static class ServiceCollectionExtensions
     {
-        private const string DefaultOpenAiSectionName = "OpenAI";
-
         public static IServiceCollection AddOpenAiTranslator(this IServiceCollection services,
-            IConfiguration configuration, string? sectionName = null)
+            IConfiguration configuration, string sectionName)
         {
             services.AddOptions<OpenAiOptions>()
-                .Bind(configuration.GetSection(sectionName ?? DefaultOpenAiSectionName))
+                .Bind(configuration.GetSection(sectionName))
                 .ValidateDataAnnotations()
                 .ValidateOnStart();
 

--- a/src/Diksy.WebApi/Controllers/TranslationController.cs
+++ b/src/Diksy.WebApi/Controllers/TranslationController.cs
@@ -11,7 +11,7 @@ namespace Diksy.WebApi.Controllers
     /// </summary>
     [ApiController]
     [Route("api/[controller]")]
-    [EnableRateLimiting("translation")]
+    [EnableRateLimiting("default")]
     [ProducesResponseType(type: typeof(ApiProblemDetails), statusCode: StatusCodes.Status400BadRequest)]
     [ProducesResponseType(type: typeof(ApiProblemDetails), statusCode: StatusCodes.Status500InternalServerError)]
     [ProducesResponseType(type: typeof(ApiProblemDetails), statusCode: StatusCodes.Status429TooManyRequests)]

--- a/src/Diksy.WebApi/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Diksy.WebApi/Extensions/ServiceCollectionExtensions.cs
@@ -1,12 +1,53 @@
 using Diksy.WebApi.Services;
+using Diksy.WebApi.Settings;
+using Microsoft.AspNetCore.RateLimiting;
+using NSwag;
 
 namespace Diksy.WebApi.Extensions
 {
     public static class ServiceCollectionExtensions
     {
-        public static IServiceCollection AddApiDependencies(this IServiceCollection services)
+        public static IServiceCollection AddApiDependencies(this IServiceCollection services,
+            IConfiguration configuration)
         {
             services.AddScoped<ITranslationService, TranslationService>();
+
+            services.AddOpenApiDocument(config =>
+            {
+                config.PostProcess = document =>
+                {
+                    document.Info.Version = "v1";
+                    document.Info.Title = "Diksy Translation API";
+                    document.Info.Description = "API for translating phrases using AI";
+                    document.Info.Contact = new OpenApiContact { Name = "Support", Email = "support@diksy.com" };
+                };
+            });
+
+            services.AddOptions<RateLimitingOptions>()
+                .Bind(configuration.GetSection(ConfigurationSections.RateLimiting))
+                .ValidateDataAnnotations()
+                .ValidateOnStart();
+
+            RateLimitingOptions rateLimitingSettings =
+                configuration.GetSection(ConfigurationSections.RateLimiting).Get<RateLimitingOptions>()
+                ?? new RateLimitingOptions();
+
+            services.AddRateLimiter(options =>
+            {
+                if (rateLimitingSettings.Enabled)
+                {
+                    options.AddFixedWindowLimiter(policyName: "default", configureOptions: config =>
+                    {
+                        config.Window = TimeSpan.FromMinutes(rateLimitingSettings.WindowInMinutes);
+                        config.PermitLimit = rateLimitingSettings.PermitLimit;
+                        config.QueueLimit = rateLimitingSettings.QueueLimit;
+                        config.QueueProcessingOrder = rateLimitingSettings.QueueProcessingOrder;
+                    });
+                }
+
+                options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+            });
+            
             return services;
         }
     }

--- a/src/Diksy.WebApi/Settings/ConfigurationSections.cs
+++ b/src/Diksy.WebApi/Settings/ConfigurationSections.cs
@@ -1,0 +1,9 @@
+﻿namespace Diksy.WebApi.Settings
+{
+    public sealed class ConfigurationSections
+    {
+        public const string RateLimiting = "RateLimiting";
+        public const string OpenAi = "OpenAI";
+        public const string Mongo = "Mongo";
+    }
+}

--- a/src/Diksy.WebApi/Settings/RateLimitingOptions.cs
+++ b/src/Diksy.WebApi/Settings/RateLimitingOptions.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.Threading.RateLimiting;
+
+namespace Diksy.WebApi.Settings
+{
+    public class RateLimitingOptions
+    {
+        public bool Enabled { get; set; } = true;
+
+        [Range(1, 1440, ErrorMessage = "WindowInMinutes must be between 1 and 1440 (1 day).")]
+        public int WindowInMinutes { get; set; } = 1;
+
+        [Range(1, 10000, ErrorMessage = "PermitLimit must be between 1 and 10000.")]
+        public int PermitLimit { get; set; } = 20;
+
+        [Range(0, 10000, ErrorMessage = "QueueLimit must be between 0 and 10000.")]
+        public int QueueLimit { get; set; } = 10;
+
+        public QueueProcessingOrder QueueProcessingOrder { get; set; } = QueueProcessingOrder.NewestFirst;
+    }
+}

--- a/src/Diksy.WebApi/appsettings.Development.json
+++ b/src/Diksy.WebApi/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "RateLimiting": {
+    "Enabled": false
   }
 }

--- a/src/Diksy.WebApi/appsettings.json
+++ b/src/Diksy.WebApi/appsettings.json
@@ -14,7 +14,15 @@
     "Host": "localhost:27017",
     "Username": "username",
     "Password": "password",
-    "Databases": ["diksy"]
+    "Databases": [
+      "diksy"
+    ]
+  },
+  "RateLimiting": {
+    "Enabled": true,
+    "WindowInMinutes": 1,
+    "PermitLimit": 20,
+    "QueueLimit": 10,
+    "QueueProcessingOrder": "OldestFirst"
   }
 }
- 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced configurable rate limiting with options for window duration, permit and queue limits, and processing order.
  - Added centralized configuration section names for easier management.
- **Improvements**
  - Enhanced API documentation generation with detailed metadata.
  - Refined service registration to allow more flexible configuration.
- **Configuration**
  - Added rate limiting settings to application configuration files, with the option to enable or disable in different environments.
- **Other Changes**
  - Updated parameter names in service registration methods for clarity.
  - Changed the applied rate limiting policy for translation endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->